### PR TITLE
Fixed issues with debugging

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "okapi/code-transformer",
     "description": "PHP Code Transformer is a PHP library that allows you to modify and transform the source code of a loaded PHP class.",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "type": "library",
     "homepage": "https://github.com/okapi-web/php-code-transformer",
     "license": "MIT",

--- a/src/CodeTransformerKernel.php
+++ b/src/CodeTransformerKernel.php
@@ -6,6 +6,7 @@ use Closure;
 use DI\Attribute\Inject;
 use Okapi\CodeTransformer\Core\AutoloadInterceptor;
 use Okapi\CodeTransformer\Core\Cache\CacheStateManager;
+use Okapi\CodeTransformer\Core\CachedStreamFilter;
 use Okapi\CodeTransformer\Core\Container\TransformerManager;
 use Okapi\CodeTransformer\Core\DI;
 use Okapi\CodeTransformer\Core\Exception\Kernel\DirectKernelInitializationException;
@@ -45,6 +46,9 @@ abstract class CodeTransformerKernel
 
     #[Inject]
     private StreamFilter $streamFilter;
+
+    #[Inject]
+    private CachedStreamFilter $cachedStreamFilter;
 
     #[Inject]
     private AutoloadInterceptor $autoloadInterceptor;
@@ -226,6 +230,7 @@ abstract class CodeTransformerKernel
         $this->cacheStateManager->register();
 
         $this->streamFilter->register();
+        $this->cachedStreamFilter->register();
     }
 
     /**

--- a/src/Core/AutoloadInterceptor/ClassContainer.php
+++ b/src/Core/AutoloadInterceptor/ClassContainer.php
@@ -13,21 +13,28 @@ class ClassContainer
     /**
      * The class paths.
      *
-     * @var array<string, string>
+     * @var array<string, array{namespacedClass: class-string, cachedFilePath: string|null}>
      */
-    private array $namespacedClassPaths = [];
+    private array $classContext = [];
 
     /**
      * Add a class path.
      *
      * @param string $path
-     * @param string $class
+     * @param class-string $namespacedClass
+     * @param string|null $cachedFilePath
      *
      * @return void
      */
-    public function addNamespacedClassPath(string $path, string $class): void
-    {
-        $this->namespacedClassPaths[$path] = $class;
+    public function addClassContext(
+        string $path,
+        string $namespacedClass,
+        ?string $cachedFilePath = null,
+    ): void {
+        $this->classContext[$path] = [
+            'namespacedClass' => $namespacedClass,
+            'cachedFilePath' => $cachedFilePath,
+        ];
     }
 
     /**
@@ -39,6 +46,11 @@ class ClassContainer
      */
     public function getNamespacedClassByPath(string $path): string
     {
-        return $this->namespacedClassPaths[$path];
+        return $this->classContext[$path]['namespacedClass'];
+    }
+
+    public function getCachedFilePath(string $filePath): string
+    {
+        return $this->classContext[$filePath]['cachedFilePath'];
     }
 }

--- a/src/Core/CachedStreamFilter.php
+++ b/src/Core/CachedStreamFilter.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Okapi\CodeTransformer\Core;
+
+use Okapi\CodeTransformer\Core\AutoloadInterceptor\ClassContainer;
+use Okapi\CodeTransformer\Core\StreamFilter\Metadata;
+use Okapi\Filesystem\Filesystem;
+use php_user_filter as PhpStreamFilter;
+
+/**
+ * # Cached Stream Filter
+ *
+ * This class is used to register the cached stream filter.
+ *
+ * Because the PHP debugger has trouble finding the original file, we always
+ * rewrite the file path with a PHP stream filter.
+ */
+class CachedStreamFilter extends PhpStreamFilter implements ServiceInterface
+{
+    public const CACHED_FILTER_ID = 'okapi.code-transformer.cached';
+
+    private string $data = '';
+
+    public function register(): void
+    {
+        stream_filter_register(static::CACHED_FILTER_ID, static::class);
+    }
+
+    public function filter($in, $out, &$consumed, bool $closing): int
+    {
+        // Read stream until EOF
+        while ($bucket = stream_bucket_make_writeable($in)) {
+            $this->data .= $bucket->data;
+        }
+
+        // If stream is closed, return the cached file
+        if ($closing || feof($this->stream)) {
+            $consumed = strlen($this->data);
+
+            $metadata = DI::make(Metadata::class, [
+                'stream'         => $this->stream,
+                'originalSource' => $this->data,
+            ]);
+
+            $classContainer = DI::get(ClassContainer::class);
+            $cachedFilePath = $classContainer->getCachedFilePath($metadata->uri);
+
+            $source = Filesystem::readFile($cachedFilePath);
+
+            $bucket = stream_bucket_new($this->stream, $source);
+            stream_bucket_append($out, $bucket);
+
+            // Pass the (cached) source code to the next filter
+            return PSFS_PASS_ON;
+        }
+
+        // No data has been consumed
+        return PSFS_PASS_ON;
+    }
+}

--- a/src/Core/StreamFilter/FilterInjector.php
+++ b/src/Core/StreamFilter/FilterInjector.php
@@ -2,6 +2,7 @@
 
 namespace Okapi\CodeTransformer\Core\StreamFilter;
 
+use Okapi\CodeTransformer\Core\CachedStreamFilter;
 use Okapi\CodeTransformer\Core\StreamFilter;
 
 /**
@@ -39,6 +40,16 @@ class FilterInjector
             static::PHP_FILTER_READ,
             StreamFilter::FILTER_ID,
             $filePath
+        );
+    }
+
+    public function rewriteCached(string $filePath): string
+    {
+        return sprintf(
+            "%s%s/resource=%s",
+            static::PHP_FILTER_READ,
+            CachedStreamFilter::CACHED_FILTER_ID,
+            $filePath,
         );
     }
 }

--- a/tests/ClassLoaderMockTrait.php
+++ b/tests/ClassLoaderMockTrait.php
@@ -3,8 +3,7 @@
 namespace Okapi\CodeTransformer\Tests;
 
 use Okapi\CodeTransformer\Core\AutoloadInterceptor\ClassLoader;
-use Okapi\CodeTransformer\Core\Cache\CachePaths;
-use Okapi\CodeTransformer\Core\DI;
+use Okapi\CodeTransformer\Core\CachedStreamFilter;
 use Okapi\CodeTransformer\Core\StreamFilter;
 use Okapi\CodeTransformer\Core\StreamFilter\FilterInjector;
 use Okapi\Path\Path;
@@ -65,9 +64,13 @@ trait ClassLoaderMockTrait
 
     public function assertTransformerLoadedFromCache(string $className): void
     {
-        $filePath = $this->findOriginalClassMock($className);
-        $cachePaths = DI::get(CachePaths::class);
-        $cachePath = $cachePaths->getTransformedCachePath($filePath);
+        $filePath = Path::resolve($this->findOriginalClassMock($className));
+
+        $cachePath =
+            FilterInjector::PHP_FILTER_READ .
+            CachedStreamFilter::CACHED_FILTER_ID . '/resource=' .
+            $filePath;
+
         $filePathMock = $this->findClassMock($className);
 
         Assert::assertEquals(


### PR DESCRIPTION
This passes cached files into a `CachedStreamFilter` first, so that the debugger will jump into the original file, instead of the cached one, see https://github.com/okapi-web/php-aop/issues/72#issuecomment-1882713238